### PR TITLE
Fix the composer provide rules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "squizlabs/php_codesniffer": "3.*"
     },
     "provide": {
-        "psr/http-client": "^1.0"
+        "psr/http-client-implementation": "1.0"
     },
     "archive": {
         "exclude": ["build/", "composer.lock"]


### PR DESCRIPTION
This package does not contain the source code of the psr/http-client interfaces, and so it does not provide the psr/http-client package. What is provided is a class implementing the interface.
Refs https://github.com/composer/composer/issues/9308